### PR TITLE
Added a flag (--local-linux) to the build.py script to perform SortMeRNA build locally  Fix #374

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -2,23 +2,21 @@
 
 # Contents
 
-- [Building from source code](#building-from-source-code)
-- [Contents](#contents)
-	- [General notes](#general-notes)
-	- [Building on Linux](#building-on-linux)
-		- [Install GCC 9](#install-gcc-9)
-		- [Install Devtoolset 9](#install-devtoolset-9)
-		- [get Sortmerna sources](#get-sortmerna-sources)
-		- [Install Conda](#install-conda)
-		- [Install CMake](#install-cmake)
-		- [build](#build)
-	- [Building on Windows](#building-on-windows)
-		- [Install Visual Studio](#install-visual-studio)
-		- [Install Conda](#install-conda-1)
-		- [get Sortmerna sources](#get-sortmerna-sources-1)
-		- [build](#build-1)
-	- [Building on Mac](#building-on-mac)
-	- [Third-party libraries](#third-party-libraries)
+- [General notes](#general-notes)
+- [Building on Linux](#building-on-linux)
+	- [Install GCC 9](#install-gcc-9)
+	- [Install Devtoolset 9](#install-devtoolset-9)
+	- [get Sortmerna sources](#get-sortmerna-sources)
+	- [Install Conda](#install-conda)
+	- [Install CMake](#install-cmake)
+	- [build](#build)
+- [Building on Windows](#building-on-windows)
+	- [Install Visual Studio](#install-visual-studio)
+	- [Install Conda](#install-conda-1)
+	- [get Sortmerna sources](#get-sortmerna-sources-1)
+	- [build](#build-1)
+- [Building on Mac](#building-on-mac)
+- [Third-party libraries](#third-party-libraries)
 
 ## General notes
 
@@ -128,6 +126,14 @@ vi $SMR_HOME/scripts/env.yaml
 
 # run the build
 python $SMR_HOME/scripts/build.py --name all [--env $SMR_HOME/script/my_env.yaml]
+```
+
+### Quick build
+
+The following command will compile SortMeRNA local sources in the current working directory on a linux machine:
+
+```
+python scripts/build.py --name all --local-linux
 ```
 
 ## Building on Windows

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [v4.3.7]
 
+### Added 
+
+- [[#374](https://github.com/sortmerna/sortmerna/issues/374)] - added `--local-linux` flag to the `build.py` script to allow for a straightforward build of local sources in the current working directory
+
 ### Changed
 
 - [[#365](https://github.com/sortmerna/sortmerna/issues/365)] - updated CHANGELOG so it now follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) standards

--- a/scripts/build.py
+++ b/scripts/build.py
@@ -723,6 +723,7 @@ if __name__ == "__main__":
     optpar.add_option('--config', dest='config', help='Build configuration file.')
     optpar.add_option('--build-dir', dest='build_dir', help='Build directory.')
     optpar.add_option('--dist-dir', dest='dist_dir', help='Distro directory.')
+    optpar.add_option('--local-linux', dest='local_linux', action='store_true', help='Perform the build on local source files in the current working directory.')
     (opts, args) = optpar.parse_args()
 
     UHOME = os.environ['USERPROFILE'] if IS_WIN else os.environ['HOME']
@@ -730,9 +731,53 @@ if __name__ == "__main__":
     cur_dir = os.path.dirname(os.path.realpath(__file__)) # directory where this script is located
     print(f'{STAMP} Current dir: {cur_dir}')
 
-    if opts.envfile:
+    if opts.local_linux:
+        cur_wdir = os.getcwd()
+
+        LIB_DIR = cur_wdir
+
+        URL_ZLIB   = 'https://github.com/madler/zlib.git'
+        URL_ROCKS  = 'https://github.com/facebook/rocksdb.git'
+        URL_DIRENT = 'https://github.com/tronkko/dirent'
+        #URL_RAPID  = https://github.com/Tencent/rapidjson
+        URL_SMR    = 'https://github.com/biocore/sortmerna.git'
+        URL_CONCURRENTQUEUE = 'https://github.com/cameron314/concurrentqueue'
+
+        CMAKE_GEN = 'Unix Makefiles'
+
+        # SMR
+        SMR_SRC   = cur_wdir
+        SMR_BUILD = f'{cur_wdir}/build'
+        SMR_DIST  = f'{cur_wdir}/dist'
+        SMR_VER = None
+
+        # ZLIB
+        ZLIB_SRC = f'{cur_wdir}/{ZLIB}'
+        ZLIB_BUILD = f'{ZLIB_SRC}/build'
+        ZLIB_DIST = f'{ZLIB_SRC}/dist'
+
+        # ROCKSDB
+        ROCKS_SRC = f'{cur_wdir}/{ROCKS}'
+        ROCKS_BUILD = f'{ROCKS_SRC}/build'
+        ROCKS_DIST = f'{ROCKS_SRC}/dist'
+        ROCKS_VER = None
+
+        # RAPIDJSON
+        # no binaries, so always build Release only
+        """
+        RAPID_SRC = f'{cur_wdir}/{RAPID}'
+        RAPID_BUILD = f'{RAPID_SRC}/build'
+        RAPID_DIST = f'{RAPID_SRC}/dist'
+        """
+
+        # CONCURRENTQUEUE
+        CCQUEUE_SRC = f'{cur_wdir}/{CCQUEUE}'
+
+        env = {}
+
+    else:
         # check env.yaml. If no env file specified, try the current directory
-        envfile = opts.envfile
+        envfile = os.path.join(cur_dir, 'env.jinja') if not opts.envfile else opts.envfile
         if not os.path.exists(envfile):
             print(f'{STAMP} No environment config file found. Please, provide one using \'--env\' option')
             sys.exit(1)
@@ -823,50 +868,7 @@ if __name__ == "__main__":
             val = env.get(DIRENT, {}).get('dist')
             DIRENT_DIST = val.get(ENV) if val and isinstance(val, dict) else DIRENT_SRC
 
-    else:
-        cur_wdir = os.getcwd()
-
-        LIB_DIR = cur_wdir
-
-        URL_ZLIB   = 'https://github.com/madler/zlib.git'
-        URL_ROCKS  = 'https://github.com/facebook/rocksdb.git'
-        URL_DIRENT = 'https://github.com/tronkko/dirent'
-        #URL_RAPID  = https://github.com/Tencent/rapidjson
-        URL_SMR    = 'https://github.com/biocore/sortmerna.git'
-        URL_CONCURRENTQUEUE = 'https://github.com/cameron314/concurrentqueue'
-
-        CMAKE_GEN = 'Unix Makefiles'
-
-        # SMR
-        SMR_SRC   = cur_wdir
-        SMR_BUILD = f'{cur_wdir}/build'
-        SMR_DIST  = f'{cur_wdir}/dist'
-        SMR_VER = None
-
-        # ZLIB
-        ZLIB_SRC = f'{cur_wdir}/{ZLIB}'
-        ZLIB_BUILD = f'{ZLIB_SRC}/build'
-        ZLIB_DIST = f'{ZLIB_SRC}/dist'
-
-        # ROCKSDB
-        ROCKS_SRC = f'{cur_wdir}/{ROCKS}'
-        ROCKS_BUILD = f'{ROCKS_SRC}/build'
-        ROCKS_DIST = f'{ROCKS_SRC}/dist'
-        ROCKS_VER = None
-
-        # RAPIDJSON
-        # no binaries, so always build Release only
-        """
-        RAPID_SRC = f'{cur_wdir}/{RAPID}'
-        RAPID_BUILD = f'{RAPID_SRC}/build'
-        RAPID_DIST = f'{RAPID_SRC}/dist'
-        """
-
-        # CONCURRENTQUEUE
-        CCQUEUE_SRC = f'{cur_wdir}/{CCQUEUE}'
-
-        env = {}
-
+    
     # call functions
     if opts.name:
         if opts.name == ALL:

--- a/scripts/build.py
+++ b/scripts/build.py
@@ -826,6 +826,8 @@ if __name__ == "__main__":
     else:
         cur_wdir = os.getcwd()
 
+        LIB_DIR = cur_wdir
+
         URL_ZLIB   = 'https://github.com/madler/zlib.git'
         URL_ROCKS  = 'https://github.com/facebook/rocksdb.git'
         URL_DIRENT = 'https://github.com/tronkko/dirent'


### PR DESCRIPTION
This new flag allows the user to bypass the env.jinja file if they want to perform a straightforward local build on a linux machine. The default behaviour of the build.py script (without the `--local-linux`) to call the env.jinja file remains the same.